### PR TITLE
fix; detection to coco with empty mask

### DIFF
--- a/supervision/dataset/formats/coco.py
+++ b/supervision/dataset/formats/coco.py
@@ -134,6 +134,8 @@ def detections_to_coco_annotations(
                     "counts": mask_to_rle(mask=mask),
                     "size": list(mask.shape[:2]),
                 }
+            elif mask.sum() == 0:
+                segmentation = []
             else:
                 segmentation = [
                     list(


### PR DESCRIPTION
bug fix; supervision could not handle bbox with empty mask.
Now we create an empty segmentation