### PR TITLE
Yolo nested

### DIFF
--- a/supervision/dataset/formats/yolo.py
+++ b/supervision/dataset/formats/yolo.py
@@ -70,9 +70,29 @@ def _extract_class_names(file_path: str) -> list[str]:
     return names
 
 
-def _image_name_to_annotation_name(image_name: str) -> str:
-    base_name, _ = os.path.splitext(image_name)
-    return base_name + ".txt"
+def _relative_image_path(image_path: str, image_directory_name="images"):
+    """
+    Returns the relative path starting from a directory name.
+
+    Default image base directory is "images"
+    """
+    images_dirname = os.path.sep + image_directory_name + os.path.sep
+    relative_path_image = image_path.split(images_dirname)[-1]
+    return relative_path_image
+
+
+def _image_path_to_annotation_path(image_path: str) -> str:
+    """
+    Returns the yolo-style annotation path.
+
+    Note that ultralytics finds annotations by replacing "/images/" with "/annotations/"
+    For nested image directories, the annotations should be stored in a nested
+    directory as well.
+    """
+    relative_path_image = _relative_image_path(image_path)
+    base_name, _ = os.path.splitext(relative_path_image)
+    relative_path_annotation = base_name + ".txt"
+    return relative_path_annotation
 
 
 def yolo_annotations_to_detections(
@@ -270,11 +290,13 @@ def save_yolo_annotations(
 ) -> None:
     Path(annotations_directory_path).mkdir(parents=True, exist_ok=True)
     for image_path, image, annotation in dataset:
-        image_name = Path(image_path).name
-        yolo_annotations_name = _image_name_to_annotation_name(image_name=image_name)
-        yolo_annotations_path = os.path.join(
-            annotations_directory_path, yolo_annotations_name
+        yolo_annotations_path_rel = _image_path_to_annotation_path(
+            image_path=image_path
         )
+        yolo_annotations_path_abs = (
+            Path(annotations_directory_path) / yolo_annotations_path_rel
+        )
+        yolo_annotations_path_abs.parent.mkdir(exist_ok=True, parents=True)
         lines = detections_to_yolo_annotations(
             detections=annotation,
             image_shape=image.shape,  # type: ignore
@@ -282,7 +304,7 @@ def save_yolo_annotations(
             max_image_area_percentage=max_image_area_percentage,
             approximation_percentage=approximation_percentage,
         )
-        save_text_file(lines=lines, file_path=yolo_annotations_path)
+        save_text_file(lines=lines, file_path=yolo_annotations_path_abs)
 
 
 def save_data_yaml(data_yaml_path: str, classes: list[str]) -> None:

--- a/test/dataset/formats/test_yolo.py
+++ b/test/dataset/formats/test_yolo.py
@@ -6,7 +6,7 @@ import numpy as np
 import pytest
 
 from supervision.dataset.formats.yolo import (
-    _image_name_to_annotation_name,
+    _image_path_to_annotation_path,
     _with_mask,
     object_to_yolo,
     yolo_annotations_to_detections,
@@ -200,13 +200,18 @@ def test_yolo_annotations_to_detections(
             "image.000.txt",
             DoesNotRaise(),
         ),  # jpg image with multiple dots in name
+        (
+            "dataset/images/subdir/image.jpg",
+            "subdir/image.txt",
+            DoesNotRaise(),
+        ),  # dataset with nested directories
     ],
 )
-def test_image_name_to_annotation_name(
+def test_image_path_to_annotation_path(
     image_name: str, expected_result: str | None, exception: Exception
 ) -> None:
     with exception:
-        result = _image_name_to_annotation_name(image_name=image_name)
+        result = _image_path_to_annotation_path(image_path=image_name)
         assert result == expected_result
 
 


### PR DESCRIPTION
# Description
Bugfix ; correctly save yolo annotations for dataset with nested image directories.

Ultralytics find the annotation path based on the image path, by replacing "/images/" with "/labels/".
This means that any subdirectories in the images folder have to be mirrored in the label folder, DetectionDataset.as_coco previously did not account for.

Test has been added to verify that this new behaviour is working as intented.