### PR TITLE
improve yolo writing speed via threadpool

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,7 +130,7 @@ indent-width = 4
 [tool.ruff.lint]
 # Enable pycodestyle (`E`) and Pyflakes (`F`) codes by default.
 select = ["E", "F", "I", "A", "Q", "W", "RUF", "UP"]
-ignore = []
+ignore = ["RUF059"]
 # Allow autofix for all enabled rules (when `--fix`) is provided.
 fixable = [
     "A",

--- a/supervision/dataset/formats/coco.py
+++ b/supervision/dataset/formats/coco.py
@@ -16,6 +16,7 @@ from supervision.detection.core import Detections
 from supervision.detection.utils.converters import polygon_to_mask
 from supervision.detection.utils.masks import contains_holes, contains_multiple_segments
 from supervision.utils.file import read_json_file, save_json_file
+from supervision.utils.image import load_image_shape_quick
 
 if TYPE_CHECKING:
     from supervision.dataset.core import DetectionDataset
@@ -281,11 +282,14 @@ def save_coco_annotations(
     coco_categories = classes_to_coco_categories(classes=dataset.classes)
 
     image_id, annotation_id = 1, 1
-    for image_path, image, annotation in dataset:
-        image_height, image_width, _ = image.shape
+    for image_path in dataset.image_paths:
+        annotation = dataset.annotations[image_path]
         # NOTE: we save the image name as a relative path
         # from the annotation file location
         image_path_absolute = Path(image_path).resolve()
+        (image_height, image_width, _) = load_image_shape_quick(
+            str(image_path_absolute)
+        )
         image_path_relative = os.path.relpath(
             image_path_absolute, start=annotation_path.parent
         )

--- a/supervision/dataset/formats/yolo.py
+++ b/supervision/dataset/formats/yolo.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import os
+from functools import partial
+from multiprocessing.pool import ThreadPool
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -289,22 +291,45 @@ def save_yolo_annotations(
     approximation_percentage: float = 0.75,
 ) -> None:
     Path(annotations_directory_path).mkdir(parents=True, exist_ok=True)
-    for image_path, image, annotation in dataset:
-        yolo_annotations_path_rel = _image_path_to_annotation_path(
-            image_path=image_path
+
+    with ThreadPool() as pool:
+        pool.map(
+            partial(
+                save_yolo_annotation,
+                dataset=dataset,
+                annotations_directory_path=annotations_directory_path,
+                min_image_area_percentage=min_image_area_percentage,
+                max_image_area_percentage=max_image_area_percentage,
+                approximation_percentage=approximation_percentage,
+            ),
+            range(len(dataset)),
         )
-        yolo_annotations_path_abs = (
-            Path(annotations_directory_path) / yolo_annotations_path_rel
-        )
-        yolo_annotations_path_abs.parent.mkdir(exist_ok=True, parents=True)
-        lines = detections_to_yolo_annotations(
-            detections=annotation,
-            image_shape=image.shape,  # type: ignore
-            min_image_area_percentage=min_image_area_percentage,
-            max_image_area_percentage=max_image_area_percentage,
-            approximation_percentage=approximation_percentage,
-        )
-        save_text_file(lines=lines, file_path=yolo_annotations_path_abs)
+    return
+
+
+def save_yolo_annotation(
+    index: int,
+    dataset: DetectionDataset,
+    annotations_directory_path: str,
+    min_image_area_percentage: float = 0.0,
+    max_image_area_percentage: float = 1.0,
+    approximation_percentage: float = 0.75,
+) -> None:
+    image_path, image, annotation = dataset[index]
+    yolo_annotations_path_rel = _image_path_to_annotation_path(image_path=image_path)
+    yolo_annotations_path_abs = (
+        Path(annotations_directory_path) / yolo_annotations_path_rel
+    )
+    yolo_annotations_path_abs.parent.mkdir(exist_ok=True, parents=True)
+    lines = detections_to_yolo_annotations(
+        detections=annotation,
+        image_shape=image.shape,  # type: ignore
+        min_image_area_percentage=min_image_area_percentage,
+        max_image_area_percentage=max_image_area_percentage,
+        approximation_percentage=approximation_percentage,
+    )
+    save_text_file(lines=lines, file_path=yolo_annotations_path_abs)
+    return
 
 
 def save_data_yaml(data_yaml_path: str, classes: list[str]) -> None:

--- a/supervision/dataset/formats/yolo.py
+++ b/supervision/dataset/formats/yolo.py
@@ -20,6 +20,7 @@ from supervision.utils.file import (
     save_text_file,
     save_yaml_file,
 )
+from supervision.utils.image import load_image_shape_quick
 
 if TYPE_CHECKING:
     from supervision.dataset.core import DetectionDataset
@@ -315,7 +316,10 @@ def save_yolo_annotation(
     max_image_area_percentage: float = 1.0,
     approximation_percentage: float = 0.75,
 ) -> None:
-    image_path, image, annotation = dataset[index]
+    image_path = dataset.image_paths[index]
+    image_shape = load_image_shape_quick(image_path)
+    annotation = dataset.annotations[image_path]
+
     yolo_annotations_path_rel = _image_path_to_annotation_path(image_path=image_path)
     yolo_annotations_path_abs = (
         Path(annotations_directory_path) / yolo_annotations_path_rel
@@ -323,7 +327,7 @@ def save_yolo_annotation(
     yolo_annotations_path_abs.parent.mkdir(exist_ok=True, parents=True)
     lines = detections_to_yolo_annotations(
         detections=annotation,
-        image_shape=image.shape,  # type: ignore
+        image_shape=image_shape,  # type: ignore
         min_image_area_percentage=min_image_area_percentage,
         max_image_area_percentage=max_image_area_percentage,
         approximation_percentage=approximation_percentage,

--- a/supervision/utils/image.py
+++ b/supervision/utils/image.py
@@ -11,7 +11,7 @@ from typing import Literal
 import cv2
 import numpy as np
 import numpy.typing as npt
-from PIL import Image, ImageOps
+from PIL import ExifTags, Image
 
 from supervision.annotators.base import ImageType
 from supervision.draw.color import Color, unify_to_bgr
@@ -40,9 +40,29 @@ def load_image_shape_quick(path: str) -> tuple[int, int, int]:
     via opencv.imread, for PIL we need to explicitly do it.
     """
     with Image.open(path) as img:
-        ImageOps.exif_transpose(img, in_place=True)
         (width, height) = img.size
         channels = len(img.getbands())
+
+        # correct for exif tags
+        # NOTE: the simpler ImageOps.exif_transpose loads the full
+        # image, so it's not fast
+        exif = img.getexif()
+        orientation = exif.get(ExifTags.Base.Orientation, 1)
+        method = {
+            2: Image.Transpose.FLIP_LEFT_RIGHT,
+            3: Image.Transpose.ROTATE_180,
+            4: Image.Transpose.FLIP_TOP_BOTTOM,
+            5: Image.Transpose.TRANSPOSE,
+            6: Image.Transpose.ROTATE_270,
+            7: Image.Transpose.TRANSVERSE,
+            8: Image.Transpose.ROTATE_90,
+        }.get(orientation)
+        if method in [
+            Image.Transpose.TRANSPOSE,
+            Image.Transpose.ROTATE_90,
+            Image.Transpose.ROTATE_270,
+        ]:
+            (height, width) = (width, height)
     return height, width, channels
 
 

--- a/supervision/utils/image.py
+++ b/supervision/utils/image.py
@@ -11,6 +11,7 @@ from typing import Literal
 import cv2
 import numpy as np
 import numpy.typing as npt
+from PIL import Image, ImageOps
 
 from supervision.annotators.base import ImageType
 from supervision.draw.color import Color, unify_to_bgr
@@ -26,6 +27,23 @@ from supervision.utils.iterables import create_batches, fill
 RelativePosition = Literal["top", "bottom"]
 
 MAX_COLUMNS_FOR_SINGLE_ROW_GRID = 3
+
+
+def load_image_shape_quick(path: str) -> tuple[int, int, int]:
+    """
+    For an image path, return image shape (height, width, channels)
+
+    Loading using Pillow is faster than using opencv, since we
+    don't load the entire image.
+
+    Exif orientation is automatically applied when loading
+    via opencv.imread, for PIL we need to explicitly do it.
+    """
+    with Image.open(path) as img:
+        ImageOps.exif_transpose(img, in_place=True)
+        (width, height) = img.size
+        channels = len(img.getbands())
+    return height, width, channels
 
 
 @ensure_cv2_image_for_processing


### PR DESCRIPTION
Saving dataset as yolo was quite slow for large datasets due to io.
With a threadpool this can already be sped up a lot.

One of the reasons that it is still relatively slow is that indexing into the DetectionDataset loads the image.
It would be faster if this can be removed as well, but for now this is a reasonable speedup.
(as far as I can see, the only reason why images are loaded are to get the image size, maybe via pillow instead of opencv) 